### PR TITLE
The PR request of absolute failure (but at least it looks nice)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ ENV/
 
 # mkdocs documentation
 /site
+
+# memory_profiler/mprof
+mprofile_*.dat
+memory_profile.png

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+test:
+	python -m pytest -s
+
+memory:
+	mprof run --multiprocess -T 0.01 tests/test_pairwise_distance.py
+	mprof plot
+
+save_plot:
+	mprof plot -o memory_profile.png
+
+clean:
+	rm mprofile_*.dat

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+test:
+	python -m pytest -s
+
+memory:
+	mprof run --multiprocess -T 0.01 tests/test_pairwise_distance.py
+	mprof plot
+
+save_plot:
+	mprof plot -o memory_profile.png
+
+clean:
+	rm mprofile_*.dat
+

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ In theory it is equivalent to the following (where ```N = X.shape[0]``` and ```c
 ```
 
 Importantly, however, it will not run out of memory for huge ```X```s (assuming ```X``` itself can fit into RAM).
-Space complexity is constant. 
+Space complexity is constant.
+
+## Tests
+Testing this module using `pytest` and `memory_profiler` can be easily invoked using `make`.
+* `make test` will run the basic assertion tests.
+* `make memory` will run the memory profiler and display a plot of the processes.
+* `make save_plot` will save a plot of the most recent memory profiling data as a png.
+* `make clean` will delete all the data files created by the memory profiler.
 
 ## Authors
 * __Code__: Olivia Guest [@oliviaguest](http://github.com/oliviaguest) [oliviaguest.com](http://oliviaguest.com)

--- a/pairwise_distance.py
+++ b/pairwise_distance.py
@@ -2,12 +2,11 @@ from __future__ import division
 from time import time
 from math import factorial
 from itertools import combinations
+import multiprocessing as mp
 
 import sklearn.datasets
 import scipy.spatial.distance
-
 import numpy as np
-import multiprocessing as mp
 
 ##############################
 # Code: Olivia Guest         #
@@ -15,17 +14,13 @@ import multiprocessing as mp
 ##############################
 
 
-def do_job(data_slice, job_index, queue):
-    # print job_index, data_slice.shape
-    partial_sum = 0
-    for i, points in enumerate(data_slice):
-        # Each data_slice has tuples consisting of two points that we need to
-        # find the Euclidean distance between and their weight:
-        # points[2] are the weights for the pair points[0] and points[1]
-        partial_sum += np.sum(points[2] *
-                              np.sqrt(np.sum((points[0] - points[1])**2,
-                                      axis=1)))
-    queue.put(partial_sum)
+def do_job(data_slice, queue):
+    # Each data_slice has tuples consisting of two points that we need to
+    # find the Euclidean distance between and their weight:
+    # points[2] are the weights for the pair points[0] and points[1]
+    slice_sum = np.sum(np.dot(weights, np.sqrt(np.sum((X - Y)**2, axis=1)))
+                       for X, Y, weights in data_slice)
+    queue.put(slice_sum)
 
 # If you want to memory profile this funtion to see it is roughly constant,
 # feel free to comment in the decorator and run with memory_profiler (install
@@ -34,7 +29,7 @@ def do_job(data_slice, job_index, queue):
 # @profile
 
 
-def mean_pairwise_distance(X, weights=None, n_jobs=None):
+def mean_pairwise_distance(X, weights=None, n_jobs=None, axis=0):
     """Function that returns the sum and mean of the pairwise distances of an 2D
     array X.
 
@@ -43,34 +38,32 @@ def mean_pairwise_distance(X, weights=None, n_jobs=None):
 
     Optional arguments:
     weights -- 1D array of counts or weights per point in X (default: 1s).
-    n_jobs  -- Numper of cores to use for calulation (default: all).
+    n_jobs  -- Number of cores to use for calulation (default: all).
+    axis    -- The axis of X corresponding to data elements (default: 0).
     """
-    N = X.shape[0]
+    N = X.shape[axis]
     if weights is None:
         weights = np.ones((N,))
     if n_jobs is None:
         n_jobs = mp.cpu_count()
+
     # Get the pairs and their weights to calculate the distances without
     # needing the whole of X:
     pairs = [(X[i:], X[:N - i], weights[i:] * weights[:N - i])
              for i in xrange(1, N)]
-    # Create slices of the pairs to send to each worker:
+    # Create approximately equal splits of the pairs for each cpu:
     pairs_slices = np.array_split(pairs, n_jobs)
-    jobs = []
-    queues = []
-    for i, pairs_slice in enumerate(pairs_slices):
-        # We need queues to get the data back from each worker function:
-        queues.append(mp.Queue())
-        # Create a job and append it to the list of jobs:
-        jobs.append(mp.Process(
-            target=do_job, args=(pairs_slice, i, queues[i])))
-    # Start all the jobs:
+
+    # Make queues to collect results and processes to do the calculations:
+    queues = [mp.Queue() for i in xrange(n_jobs)]
+    jobs = [mp.Process(target=do_job, args=(pairs_slice, queue))
+            for queue, pairs_slice in zip(queues, pairs_slices)]
+
+    # Start all the jobs, aggregate the sum when they finish:
     for j in jobs:
         j.start()
-    # Calculate the sum:
-    queue_sum = 0
-    for q in queues:
-        queue_sum += q.get()
+    queue_sum = sum(q.get() for q in queues)
+
     # Compute the number of combinations, add to the number of unique pairs
     # and use that as the denominator to calculate the mean pairwise distance:
     mean = queue_sum / (((N - 1)**2 + (N + 1)) / 2 + N)
@@ -81,21 +74,28 @@ def mean_pairwise_distance(X, weights=None, n_jobs=None):
 if __name__ == "__main__":
     # Generate some data:
     N = 1000
-    centers = [[0, 0], [1, 0], [0.5, np.sqrt(0.75)]]
-    cluster_std = [0.3, 0.3, 0.3]
+    np.random.seed(10)
+    n_jobs = mp.cpu_count()
+    n_samples = N * 3 // 4  # same as floor(3/4 * N)
+
+    # Blob set 1
+    centers = [[0., 0.],
+               [1., 0.],
+               [0.5, np.sqrt(0.75)]]
     n_clusters = len(centers)
-    n_samples = int(0.75 * N)
+    cluster_std = [0.3] * n_clusters
     data, labels_true = sklearn.datasets.make_blobs(n_samples=n_samples,
                                                     centers=centers,
                                                     cluster_std=cluster_std)
+
+    # Blob set 2
     centers = [[0.5, np.sqrt(0.75)]]
-    cluster_std = [0.3]
     n_clusters = len(centers)
-    extra, labels_true = sklearn.datasets.make_blobs(n_samples=int(0.25 * N),
+    cluster_std = [0.3] * n_clusters
+    extra, labels_true = sklearn.datasets.make_blobs(n_samples=N - n_samples,
                                                      centers=centers,
                                                      cluster_std=cluster_std)
     X = np.concatenate((data, extra), axis=0)
-    N = X.shape[0]
 
     # Pick some random floats for the counts/weights:
     counts = np.random.random_sample((N,)) * 10
@@ -103,24 +103,24 @@ if __name__ == "__main__":
     # Parallel:
     # Parallelised code partially based on:
     # https://gist.github.com/baojie/6047780
-    t = time()
+    t_start = time()
     parallel_sum, parallel_mean = mean_pairwise_distance(X,
                                                          weights=counts,
-                                                         n_jobs=mp.cpu_count()
-                                                         )
-    print 'parallel:\t{} s'.format(time() - t)
+                                                         n_jobs=n_jobs)
+    t_end = time()
+    print 'parallel:\t{} s'.format(t_end - t_start)
     ##########################################################################
 
     ##########################################################################
     # Serial:
     # Comment this out if you use a high N as it will eat RAM!
-    t = time()
-    Y = scipy.spatial.distance.pdist(X, 'euclidean')
-    weights = [counts[i] * counts[j]
-               for i in xrange(N - 1) for j in xrange(i + 1, N)]
-    serial_sum = np.sum(weights * Y)
+    t_start = time()
+    weights = np.array([counts[i] * counts[j]
+                       for i in xrange(N - 1) for j in xrange(i + 1, N)])
+    serial_sum = np.dot(weights, scipy.spatial.distance.pdist(X, 'euclidean'))
     serial_mean = serial_sum / (((N - 1)**2 + (N + 1)) / 2 + N)
-    print 'serial:\t\t{} s'.format(time() - t)
+    t_end = time()
+    print 'serial:\t\t{} s'.format(t_end - t_start)
     ##########################################################################
 
     # There is minor rounding error, but check for equality:

--- a/pairwise_distance.py
+++ b/pairwise_distance.py
@@ -1,11 +1,6 @@
 from __future__ import division
-from time import time
-from math import factorial
-from itertools import combinations
 import multiprocessing as mp
 
-import sklearn.datasets
-import scipy.spatial.distance
 import numpy as np
 
 ##############################
@@ -20,13 +15,6 @@ def batch_pdist(data_slice):
     # points[2] are the weights for the pair points[0] and points[1]
     return np.sum(np.dot(weights, np.sqrt(np.sum((X - Y)**2, axis=1)))
                   for X, Y, weights in data_slice)
-
-# If you want to memory profile this funtion to see it is roughly constant,
-# feel free to comment in the decorator and run with memory_profiler (install
-# it) as below:
-# python -m memory_profiler pairwise_distance.py
-# @profile
-
 
 def mean_pairwise_distance(X, weights=None, n_jobs=None, axis=0):
     """Function that returns the sum and mean of the pairwise distances of an 2D
@@ -66,61 +54,3 @@ def mean_pairwise_distance(X, weights=None, n_jobs=None, axis=0):
     # mean = queue_sum / (((N - 1)**2 + (N + 1)) / 2.0)
 
     return queue_sum, mean
-
-if __name__ == "__main__":
-    # Generate some data:
-    N = 1000
-    np.random.seed(10)
-    n_jobs = mp.cpu_count()
-    n_samples = N * 3 // 4  # same as floor(3/4 * N)
-
-    # Blob set 1
-    centers = [[0., 0.],
-               [1., 0.],
-               [0.5, np.sqrt(0.75)]]
-    n_clusters = len(centers)
-    cluster_std = [0.3] * n_clusters
-    data, labels_true = sklearn.datasets.make_blobs(n_samples=n_samples,
-                                                    centers=centers,
-                                                    cluster_std=cluster_std)
-
-    # Blob set 2
-    centers = [[0.5, np.sqrt(0.75)]]
-    n_clusters = len(centers)
-    cluster_std = [0.3] * n_clusters
-    extra, labels_true = sklearn.datasets.make_blobs(n_samples=N - n_samples,
-                                                     centers=centers,
-                                                     cluster_std=cluster_std)
-    X = np.concatenate((data, extra), axis=0)
-
-    # Pick some random floats for the counts/weights:
-    counts = np.random.random_sample((N,)) * 10
-    ##########################################################################
-    # Parallel:
-    # Parallelised code partially based on:
-    # https://gist.github.com/baojie/6047780
-    t_start = time()
-    parallel_sum, parallel_mean = mean_pairwise_distance(X,
-                                                         weights=counts,
-                                                         n_jobs=n_jobs)
-    t_end = time()
-    print 'parallel:\t{} s'.format(t_end - t_start)
-    ##########################################################################
-
-    ##########################################################################
-    # Serial:
-    # Comment this out if you use a high N as it will eat RAM!
-    t_start = time()
-    weights = np.array([counts[i] * counts[j]
-                       for i in xrange(N - 1) for j in xrange(i + 1, N)])
-    serial_sum = np.dot(weights, scipy.spatial.distance.pdist(X, 'euclidean'))
-    serial_mean = serial_sum / (((N - 1)**2 + (N + 1)) / 2 + N)
-    t_end = time()
-    print 'serial:\t\t{} s'.format(t_end - t_start)
-    ##########################################################################
-
-    # There is minor rounding error, but check for equality:
-    assert np.round(serial_sum) == np.round(parallel_sum)
-    assert np.round(serial_mean) == np.round(parallel_mean)
-    print 'sum = {}'.format(parallel_sum)
-    print 'mean = {}'.format(parallel_mean)

--- a/tests/test_pairwise_distance.py
+++ b/tests/test_pairwise_distance.py
@@ -1,0 +1,103 @@
+from __future__ import division
+from time import time
+import multiprocessing as mp
+
+from scipy.spatial.distance import pdist
+from sklearn.datasets import make_blobs
+import numpy as np
+
+# This workaround (read: hack) makes pytest and memory_profiler play nice:
+from os import path
+import sys
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+from pairwise_distance import mean_pairwise_distance
+
+
+def generate_data(N, seed=10):
+    """ This generates some test data that we can use to test our pairwise-
+    distance functions.
+
+    Required arguments:
+    N       -- The number of datapoints in the test data.
+
+    Optional arguments:
+    seed    -- The seed for NumPy's random module.
+    """
+
+    # Generate some data:
+    np.random.seed(seed)
+    n_samples1 = N * 3 // 4  # same as floor(3/4 * N)
+    n_samples2 = N - n_samples1
+
+    # Blob set 1
+    centers1 = [[0., 0.],
+                [1., 0.],
+                [0.5, np.sqrt(0.75)]]
+    cluster_std1 = [0.3] * len(centers1)
+    data, _ = make_blobs(n_samples=n_samples1,
+                         centers=centers1,
+                         cluster_std=cluster_std1)
+
+    # Make sure Blob 1 checks out
+
+    # Blob set 2
+    centers2 = [[0.5, np.sqrt(0.75)]]
+    cluster_std2 = [0.3] * len(centers2)
+    extra, _ = make_blobs(n_samples=n_samples2,
+                          centers=centers2,
+                          cluster_std=cluster_std2)
+
+    return np.concatenate((data, extra), axis=0)
+
+
+def test_mean_pairwise_distance(N=1000):
+    """
+    This function computes the pairwise distances on a (small) simulated
+    dataset to make sure the distributed function returns the same sum and
+    mean for pairwise distances as SciPy's pdist function.
+
+    Optional arguments:
+    N -- The number of points to use in the simulated dataset.
+    """
+
+    # Generate data and some random floats for the weights:
+    X = generate_data(N)
+    weights = np.random.random_sample((N,)) * 10
+
+    ##########################################################################
+    # Parallel:
+    # Parallelised code partially based on:
+    # https://gist.github.com/baojie/6047780
+    t_start_parallel = time()
+    parallel_sum, parallel_mean = mean_pairwise_distance(X, weights=weights)
+    t_end_parallel = time()
+    ##########################################################################
+
+    ##########################################################################
+    # Serial:
+    # Comment this out if you use a high N as it will eat RAM!
+    t_start_serial = time()
+    weights = np.array([weights[i] * weights[j]
+                       for i in xrange(N - 1) for j in xrange(i + 1, N)])
+    serial_sum = np.dot(weights, pdist(X, 'euclidean'))
+    serial_mean = serial_sum / (((N - 1)**2 + (N + 1)) / 2 + N)
+    t_end_serial = time()
+    ##########################################################################
+
+    # There is minor rounding error, but check for equality:
+    assert np.isclose(serial_sum, parallel_sum)
+    assert np.isclose(serial_mean, parallel_mean)
+
+    # Print out a nice summary of the performance and data measures:
+    def print_time(s, t):
+        return "%10s: %10.6f s" % (s, t)
+    print  # Print a newline to make things nice, due to pytest
+    print print_time('parallel', t_end_parallel - t_start_parallel)
+    print print_time('serial', t_end_serial - t_start_serial)
+    print 'sum = {}'.format(parallel_sum)
+    print 'mean = {}'.format(parallel_mean)
+
+# This file shouldn't be executed or imported on its own. This __main__ block
+# is so that external tools (e.g. memory_profiler) work correctly:
+if __name__ == "__main__":
+    test_mean_pairwise_distance()


### PR DESCRIPTION
After digging into the multiprocessing module for some time, I wasn't able to figure out a reliable and scalable way to get it to cap memory usage and parallelize the pairwise distance calculations. I did trim some excess code and get what existed working in a slightly more efficient way, and perhaps more significantly, adding some unit testing tools for easier use.

Minor changes:

- PEP8 compliance
- Remove unneeded modules
- Cut out redundant arrays and used generators where possible to ease memory usage

Major changes:
- All testing code has been moved to its own folder in the `tests` directory, making it easy to build unit tests with `pytest`. In addition, a make file has been added for reproducible testing and easy invocation of common test commands
- `mp.Processes` and `mp.Queues` have been removed and replaced with `mp.Pool`, which appears more suited to distributing and returning results as desired here. I tried to see if there were any strong arguments around for favoring Processes over Pools, but couldn't find any.

In order to get memory management to work as intended, I believe the answer lies in a combination of setting the `maxtasksperchild` parameter and `chunksize` parameter for `mp.Pool`. Otherwise, the next best solution is to look into `mmap` in to create an iterable over the out-of-core data, so that it can be loaded by pieces at a time and then passing that to the pool object.